### PR TITLE
[2.0][feature] add simple staging + environments

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,3 +1,7 @@
+# Necessary to prevent people to access git files or directories
+# http://stackoverflow.com/questions/6142437/make-git-directory-web-inaccessible
+RedirectMatch 404 /\.git
+
 # Necessary to prevent problems when using a controller named "index" and having a root index.php
 # more here: http://stackoverflow.com/q/20918746/1114320
 Options -MultiViews

--- a/application/config/Environments.php
+++ b/application/config/Environments.php
@@ -1,0 +1,7 @@
+<?php
+
+class Environments {
+    const DEV = "development";
+    const TEST = "test";
+    const PROD = "production";
+}

--- a/application/config/Stages.php
+++ b/application/config/Stages.php
@@ -1,0 +1,7 @@
+<?php
+
+class Stages {
+    const LOCAL = "local";
+    const ONLINE = "online";
+    const UNITTEST = "no";
+}

--- a/application/config/config.php
+++ b/application/config/config.php
@@ -103,7 +103,7 @@ define('COOKIE_DOMAIN', '.localhost');
  * if (ENVIRONMENT == Environments::PROD) {
  * 	define('DB_TYPE', 'mysql');
  * 	define('DB_HOST', '85.10.10.100');
- * 	define('DB_NAME', 'login');
+ * 	define('DB_NAME', 'login_' . ENVIRONEMTS::PROD);
  * 	define('DB_USER', 'prodUser');
  * 	define('DB_PASS', 'my_secret_prod_password');
  * } 

--- a/application/config/config.php
+++ b/application/config/config.php
@@ -22,6 +22,15 @@ ini_set("display_errors", 1);
  */
 define('URL', 'http://localhost/php-login/');
 
+
+/**
+ * Configuration for: Staging
+ * You can use these settings to define your database connectors, load certain scripts (bug-tracker, heatmap.js, ...) according to 
+ * your environment.
+ */
+define("ENVIRONMENT", Environments::DEV);
+define("STAGE", Stages::LOCAL);
+
 /**
  * Configuration for: Folders
  * Here you define where your folders are. Unless you have renamed them, there's no need to change this.
@@ -89,12 +98,22 @@ define('COOKIE_DOMAIN', '.localhost');
  * define('DB_USER', 'root');
  * The password of the above user
  * define('DB_PASS', 'xxx');
+ *
+ * You can and should specify the adapter for all your different environments if the variables differ.
+ * if (ENVIRONMENT == Environments::PROD) {
+ * 	define('DB_TYPE', 'mysql');
+ * 	define('DB_HOST', '85.10.10.100');
+ * 	define('DB_NAME', 'login');
+ * 	define('DB_USER', 'prodUser');
+ * 	define('DB_PASS', 'my_secret_prod_password');
+ * } 
  */
 define('DB_TYPE', 'mysql');
 define('DB_HOST', '127.0.0.1');
 define('DB_NAME', 'login');
 define('DB_USER', 'root');
 define('DB_PASS', 'mysql');
+
 
 /**
  * Configuration for: Hashing strength


### PR DESCRIPTION
This is the very easy way to add staging and environments. This can be extend if we splitted the config file. This could lead to an even better way to deploy the application on the different environments and saves the user to accidentally check in their passwords into a public repository.

If the more advanced approach should be shown as well, let me know.